### PR TITLE
fix .zips downloading as .htm on mobile devices

### DIFF
--- a/get.php
+++ b/get.php
@@ -74,5 +74,9 @@ if ($dc && count($dc) > 0) {
     file_put_contents($baseDir."/.last_error", "JSON failed to decode! " . json_last_error());
 }*/
 
+header("Cache-Control: public");
+header("Content-Description: File Transfer");
 header("Content-Disposition: attachment; filename=$filename");
+header("Content-Type: application/zip");
+header("Content-Transfer-Encoding: binary");
 readfile($baseDir . "/" . $path);


### PR DESCRIPTION
should fix mobile devices getting .htm files instead of .zip files
